### PR TITLE
Feat: Add support for og images for all pages and collections

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
     colorator (1.1.0)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
+    csv (3.3.4)
     diff-lcs (1.5.1)
     drb (2.2.0)
       ruby2_keywords
@@ -37,10 +38,10 @@ GEM
     eventmachine (1.2.7)
     ffi (1.16.3)
     forwardable-extended (2.6.0)
-    google-protobuf (4.27.1)
+    google-protobuf (4.30.2)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.27.1-arm64-darwin)
+    google-protobuf (4.30.2-arm64-darwin)
       bigdecimal
       rake (>= 13)
     http_parser.rb (0.8.0)
@@ -163,6 +164,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  csv
   jekyll-og-image!
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The plugin can be configured in the `_config.yml` file or in the post's front ma
 
 The following configuration options are available:
 
-* `content_types` - An array specifying which types of content to generate images for. Supports `"posts"`, `"pages"`, and the names of any custom collections. Default: `["posts"]`
+* `collections` - An array specifying which types of collections to generate images for. Supports `"posts"`, `"pages"`, and the names of any custom collections. Default: `["posts"]`
 
-* `output_dir` – The directory where the generated images will be saved. Images will be placed in subdirectories named after their content type (e.g., `assets/images/og/posts`, `assets/images/og/pages`). Default: `assets/images/og`
+* `output_dir` – The directory where the generated images will be saved. Images will be placed in subdirectories named after their collection type (e.g., `assets/images/og/posts`, `assets/images/og/pages`). Default: `assets/images/og`
 
 * `force` – If set to `true`, the plugin will generate an image for every document, even if the document already has an image. Default: `false`
 * `verbose`  – If set to `true`, the plugin will output additional information about the image generation process. Default: `false`
@@ -72,7 +72,7 @@ For a side wide level configuration, edit your `_config.yml`, for a post level c
 ```yaml
 # _config.yml
 og_image:
-  content_types: ["posts", "pages"]
+  collections: ["posts", "pages"]
   output_dir: "assets/images/og"
   domain: "igor.works"
   border_bottom:

--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ The plugin can be configured in the `_config.yml` file or in the post's front ma
 
 The following configuration options are available:
 
-* `output_dir` – The directory where the generated images will be saved. Default: `assets/images/og`
+* `content_types` - An array specifying which types of content to generate images for. Supports `"posts"`, `"pages"`, and the names of any custom collections. Default: `["posts"]`
 
-* `force` – If set to `true`, the plugin will generate an image for every post, even if the post already has an image. Default: `false`
+* `output_dir` – The directory where the generated images will be saved. Images will be placed in subdirectories named after their content type (e.g., `assets/images/og/posts`, `assets/images/og/pages`). Default: `assets/images/og`
 
+* `force` – If set to `true`, the plugin will generate an image for every document, even if the document already has an image. Default: `false`
 * `verbose`  – If set to `true`, the plugin will output additional information about the image generation process. Default: `false`
 
 * `skip_drafts` – If set to `true`, the plugin will skip post drafts when generating images. Default: `true`
@@ -71,6 +72,7 @@ For a side wide level configuration, edit your `_config.yml`, for a post level c
 ```yaml
 # _config.yml
 og_image:
+  content_types: ["posts", "pages"]
   output_dir: "assets/images/og"
   domain: "igor.works"
   border_bottom:

--- a/jekyll-og-image.gemspec
+++ b/jekyll-og-image.gemspec
@@ -30,4 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "zeitwerk", "~> 2.6"
   spec.add_dependency "ruby-vips", "~> 2.2.0"
   spec.add_runtime_dependency "jekyll", ">= 3.4", "< 5.0"
+
+  # Add csv as development dependency to fix load errors in tests with Ruby 3.4+
+  spec.add_development_dependency "csv"
 end

--- a/lib/jekyll_og_image/configuration.rb
+++ b/lib/jekyll_og_image/configuration.rb
@@ -49,8 +49,8 @@ class JekyllOgImage::Configuration
     to_h == other.to_h
   end
 
-  def content_types
-    @raw_config["content_types"] || ["posts"]
+  def collections
+    @raw_config["collections"] || [ "posts" ]
   end
 
   def output_dir

--- a/lib/jekyll_og_image/configuration.rb
+++ b/lib/jekyll_og_image/configuration.rb
@@ -49,6 +49,10 @@ class JekyllOgImage::Configuration
     to_h == other.to_h
   end
 
+  def content_types
+    @raw_config["content_types"] || ["posts"]
+  end
+
   def output_dir
     @raw_config["output_dir"] || "assets/images/og"
   end

--- a/lib/jekyll_og_image/generator.rb
+++ b/lib/jekyll_og_image/generator.rb
@@ -4,50 +4,91 @@ class JekyllOgImage::Generator < Jekyll::Generator
   safe true
 
   def generate(site)
-    base_path = File.join(JekyllOgImage.config.output_dir, "posts")
+    config = JekyllOgImage.config
 
-    FileUtils.mkdir_p File.join(site.config["source"], base_path)
-
-    site.posts.docs.each do |post|
-      next if post.draft? && JekyllOgImage.config.skip_drafts?
-
-      path = File.join(site.config["source"], base_path, "#{post.data['slug']}.png")
-
-      if !File.exist?(path) || JekyllOgImage.config.force?
-        Jekyll.logger.info "Jekyll Og Image:", "Generating image #{path}" if JekyllOgImage.config.verbose?
-        generate_image_for_post(site, post, path)
-      else
-        Jekyll.logger.info "Jekyll Og Image:", "Skipping image generation #{path} as it already exists." if JekyllOgImage.config.verbose?
-      end
-
-      post.data["image"] ||= {
-        "path" => File.join(base_path, "#{post.data['slug']}.png"),
-        "width" => 1200,
-        "height" => 600,
-        "alt" => post.data["title"]
-      }
+    config.content_types.each do |type|
+      process_content_type(site, type, config)
     end
   end
 
   private
 
-  def generate_image_for_post(site, post, path)
-    config = JekyllOgImage.config.merge!(post.data["og_image"])
+  def process_content_type(site, type, config)
+    Jekyll.logger.info "Jekyll Og Image:", "Processing type: #{type}" if config.verbose?
+
+    documents = get_documents_for_type(site, type)
+    return if documents.empty?
+
+    base_output_dir = File.join(config.output_dir, type)
+    absolute_output_dir = File.join(site.config["source"], base_output_dir)
+    FileUtils.mkdir_p absolute_output_dir
+
+    documents.each do |doc|
+      if doc.respond_to?(:draft?) && doc.draft? && config.skip_drafts?
+        Jekyll.logger.info "Jekyll Og Image:", "Skipping draft: #{doc.data['title']}" if config.verbose?
+        next
+      end
+
+      fallback_basename = if doc.respond_to?(:basename_without_ext)
+                          doc.basename_without_ext
+                        else
+                          File.basename(doc.name, File.extname(doc.name))
+                        end
+      slug = doc.data['slug'] || Jekyll::Utils.slugify(doc.data['title'] || fallback_basename)
+      image_filename = "#{slug}.png"
+      absolute_image_path = File.join(absolute_output_dir, image_filename)
+      relative_image_path = File.join("/", base_output_dir, image_filename) # Use leading slash for URL
+
+      if !File.exist?(absolute_image_path) || config.force?
+        Jekyll.logger.info "Jekyll Og Image:", "Generating image #{absolute_image_path}" if config.verbose?
+        generate_image_for_document(site, doc, absolute_image_path, config)
+      else
+        Jekyll.logger.info "Jekyll Og Image:", "Skipping image generation for #{relative_image_path} as it already exists." if config.verbose?
+      end
+
+      doc.data["image"] ||= {
+        "path" => relative_image_path,
+        "width" => 1200,
+        "height" => 600,
+        "alt" => doc.data["title"] 
+      }
+    end
+  end
+
+  def get_documents_for_type(site, type)
+    case type
+    when "posts"
+      site.posts.docs
+    when "pages"
+      site.pages.reject { |page| !page.html? }
+    else
+      if site.collections.key?(type)
+        site.collections[type].docs
+      else
+        Jekyll.logger.warn "Jekyll Og Image:", "Unknown content type '#{type}' configured. Skipping."
+        []
+      end
+    end
+  end
+
+  def generate_image_for_document(site, doc, path, base_config)
+    config = base_config.merge!(doc.data["og_image"] || {})
 
     canvas = generate_canvas(site, config)
     canvas = add_border_bottom(canvas, config) if config.border_bottom
     canvas = add_image(canvas, File.read(File.join(site.config["source"], config.image))) if config.image
-    canvas = add_header(canvas, post, config)
-    canvas = add_publish_date(canvas, post, config)
-    canvas = add_tags(canvas, post, config) if post.data["tags"].any?
-    canvas = add_domain(canvas, post, config) if config.domain
+    canvas = add_header(canvas, doc, config)
+    canvas = add_publish_date(canvas, doc, config)
+    canvas = add_tags(canvas, doc, config) if doc.data["tags"]&.any? 
+    canvas = add_domain(canvas, doc, config) if config.domain
 
     canvas.save(path)
   end
 
   def generate_canvas(site, config)
     background_image = if config.canvas.background_image
-      File.read(File.join(site.config["source"], config.canvas.background_image))
+      bg_path = File.join(site.config["source"], config.canvas.background_image.gsub(/^\//, ''))
+      File.exist?(bg_path) ? File.read(bg_path) : nil
     end
 
     JekyllOgImage::Element::Canvas.new(1200, 600,
@@ -72,8 +113,9 @@ class JekyllOgImage::Generator < Jekyll::Generator
     ) { |_canvas, _text| { x: 80, y: 100 } }
   end
 
-  def add_header(canvas, post, config)
-    canvas.text(post.data["title"],
+  def add_header(canvas, doc, config)
+    title = doc.data["title"] || "Untitled"
+    canvas.text(title,
       width: config.image ? 870 : 1040,
       color: config.header.color,
       dpi: 400,
@@ -81,19 +123,25 @@ class JekyllOgImage::Generator < Jekyll::Generator
     ) { |_canvas, _text| { x: 80, y: 100 } }
   end
 
-  def add_publish_date(canvas, post, config)
-    date = post.date.strftime("%B %d, %Y")
+  def add_publish_date(canvas, doc, config)
+    return canvas unless doc.respond_to?(:date) && doc.date
+
+    date = doc.date.strftime("%B %d, %Y")
+    y_pos = (doc.data["tags"]&.any? ? config.margin_bottom + 50 : config.margin_bottom)
 
     canvas.text(date,
       gravity: :sw,
       color: config.content.color,
       dpi: 150,
       font: config.content.font_family
-    ) { |_canvas, _text| { x: 80, y: post.data["tags"].any? ? config.margin_bottom + 50 : config.margin_bottom } }
+    ) { |_canvas, _text| { x: 80, y: y_pos } }
   end
 
-  def add_tags(canvas, post, config)
-    tags = post.data["tags"].map { |tag| "##{tag}" }.join(" ")
+  def add_tags(canvas, doc, config)
+    tags_list = doc.data["tags"]
+    return canvas unless tags_list.is_a?(Array) && tags_list.any?
+
+    tags = tags_list.map { |tag| "##{tag}" }.join(" ")
 
     canvas.text(tags,
       gravity: :sw,
@@ -103,17 +151,17 @@ class JekyllOgImage::Generator < Jekyll::Generator
     ) { |_canvas, _text| { x: 80, y: config.margin_bottom } }
   end
 
-  def add_domain(canvas, post, config)
+  def add_domain(canvas, doc, config)
+    y_pos = if doc.data["tags"]&.any?
+              config.margin_bottom + 50
+            else
+              config.margin_bottom
+            end
     canvas.text(config.domain,
       gravity: :se,
       color: config.content.color,
       dpi: 150,
       font: config.content.font_family
-    ) do |_canvas, _text|
-      {
-        x: 80,
-        y: post.data["tags"].any? ? config.margin_bottom + 50 : config.margin_bottom
-      }
-    end
+    ) { |_canvas, _text| { x: 80, y: y_pos } }
   end
 end

--- a/spec/jekyll_og_image_spec.rb
+++ b/spec/jekyll_og_image_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe JekyllOgImage do
     expect(Pathname.new(source_dir('assets', 'images', 'og', 'posts', 'what-is-jekyll.png'))).not_to exist
   end
 
-  # --- Tests for content_types feature ---
-  describe "when handling content_types" do
+  # --- Tests for collections feature ---
+  describe "when handling collections" do
     let(:post_image_path) { Pathname.new(source_dir('assets', 'images', 'og', 'posts', 'a-week-with-the-apple-watch.png')) }
     let(:page_image_path) { Pathname.new(source_dir('assets', 'images', 'og', 'pages', 'about-us.png')) }
     let(:collection_image_path) { Pathname.new(source_dir('assets', 'images', 'og', 'my_collection', 'item1.png')) }
 
-    context "with default configuration (no content_types specified)" do
+    context "with default configuration (no collections specified)" do
       let(:site) { Jekyll::Site.new(config) }
       let(:og_image) { JekyllOgImage::Generator.new(site.config) }
 
@@ -59,10 +59,10 @@ RSpec.describe JekyllOgImage do
       end
     end
 
-    context "when content_types specifies ['pages']" do
+    context "when collections specifies ['pages']" do
       let(:config_with_pages) do
         Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(config, {
-          "og_image" => { "content_types" => ["pages"] }
+          "og_image" => { "collections" => [ "pages" ] }
         }))
       end
       let(:site) { Jekyll::Site.new(config_with_pages) }
@@ -81,10 +81,10 @@ RSpec.describe JekyllOgImage do
       end
     end
 
-    context "when content_types specifies ['my_collection']" do
+    context "when collections specifies ['my_collection']" do
       let(:config_with_collection) do
         Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(config, {
-          "og_image" => { "content_types" => ["my_collection"] }
+          "og_image" => { "collections" => [ "my_collection" ] }
         }))
       end
       let(:site) { Jekyll::Site.new(config_with_collection) }
@@ -107,10 +107,10 @@ RSpec.describe JekyllOgImage do
       end
     end
 
-    context "when content_types specifies ['posts', 'pages']" do
+    context "when collections specifies ['posts', 'pages']" do
       let(:config_with_multiple) do
         Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(config, {
-          "og_image" => { "content_types" => ["posts", "pages"] }
+          "og_image" => { "collections" => [ "posts", "pages" ] }
         }))
       end
       let(:site) { Jekyll::Site.new(config_with_multiple) }
@@ -128,7 +128,7 @@ RSpec.describe JekyllOgImage do
     context "with front matter overrides on a page" do
       let(:config_with_pages) do
         Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(config, {
-          "og_image" => { "content_types" => ["pages"] }
+          "og_image" => { "collections" => [ "pages" ] }
         }))
       end
       let(:site) { Jekyll::Site.new(config_with_pages) }

--- a/spec/jekyll_og_image_spec.rb
+++ b/spec/jekyll_og_image_spec.rb
@@ -35,4 +35,116 @@ RSpec.describe JekyllOgImage do
 
     expect(Pathname.new(source_dir('assets', 'images', 'og', 'posts', 'what-is-jekyll.png'))).not_to exist
   end
+
+  # --- Tests for content_types feature ---
+  describe "when handling content_types" do
+    let(:post_image_path) { Pathname.new(source_dir('assets', 'images', 'og', 'posts', 'a-week-with-the-apple-watch.png')) }
+    let(:page_image_path) { Pathname.new(source_dir('assets', 'images', 'og', 'pages', 'about-us.png')) }
+    let(:collection_image_path) { Pathname.new(source_dir('assets', 'images', 'og', 'my_collection', 'item1.png')) }
+
+    context "with default configuration (no content_types specified)" do
+      let(:site) { Jekyll::Site.new(config) }
+      let(:og_image) { JekyllOgImage::Generator.new(site.config) }
+
+      before { site.read; og_image.generate(site) }
+
+      it "generates images only for posts" do
+        expect(post_image_path).to exist
+        expect(page_image_path).not_to exist
+        expect(collection_image_path).not_to exist
+      end
+
+      it "places post images in the 'posts' subdirectory" do
+        expect(post_image_path.dirname.basename.to_s).to eq("posts")
+      end
+    end
+
+    context "when content_types specifies ['pages']" do
+      let(:config_with_pages) do
+        Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(config, {
+          "og_image" => { "content_types" => ["pages"] }
+        }))
+      end
+      let(:site) { Jekyll::Site.new(config_with_pages) }
+      let(:og_image) { JekyllOgImage::Generator.new(site.config) }
+
+      before { site.read; og_image.generate(site) }
+
+      it "generates images only for pages" do
+        expect(post_image_path).not_to exist
+        expect(page_image_path).to exist
+        expect(collection_image_path).not_to exist
+      end
+
+      it "places page images in the 'pages' subdirectory" do
+        expect(page_image_path.dirname.basename.to_s).to eq("pages")
+      end
+    end
+
+    context "when content_types specifies ['my_collection']" do
+      let(:config_with_collection) do
+        Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(config, {
+          "og_image" => { "content_types" => ["my_collection"] }
+        }))
+      end
+      let(:site) { Jekyll::Site.new(config_with_collection) }
+      let(:og_image) { JekyllOgImage::Generator.new(site.config) }
+
+      before { site.read; og_image.generate(site) }
+
+      it "generates images only for the specified collection" do
+        expect(post_image_path).not_to exist
+        expect(page_image_path).not_to exist
+        expect(collection_image_path).to exist
+      end
+
+      it "places collection images in the 'my_collection' subdirectory" do
+        expect(collection_image_path.dirname.basename.to_s).to eq("my_collection")
+      end
+
+      it "handles collection items without tags gracefully" do
+        expect(collection_image_path).to exist
+      end
+    end
+
+    context "when content_types specifies ['posts', 'pages']" do
+      let(:config_with_multiple) do
+        Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(config, {
+          "og_image" => { "content_types" => ["posts", "pages"] }
+        }))
+      end
+      let(:site) { Jekyll::Site.new(config_with_multiple) }
+      let(:og_image) { JekyllOgImage::Generator.new(site.config) }
+
+      before { site.read; og_image.generate(site) }
+
+      it "generates images for both posts and pages" do
+        expect(post_image_path).to exist
+        expect(page_image_path).to exist
+        expect(collection_image_path).not_to exist
+      end
+    end
+
+    context "with front matter overrides on a page" do
+      let(:config_with_pages) do
+        Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(config, {
+          "og_image" => { "content_types" => ["pages"] }
+        }))
+      end
+      let(:site) { Jekyll::Site.new(config_with_pages) }
+      let(:og_image) { JekyllOgImage::Generator.new(site.config) }
+      let(:overridden_domain) { "overridden.example.com" }
+
+      before do
+        site.read
+        about_page = site.pages.find { |p| p.name == 'about.md' }
+        about_page.data['og_image'] = { 'domain' => overridden_domain }
+        og_image.generate(site)
+      end
+
+      it "applies front matter overrides during generation" do
+        expect(page_image_path).to exist
+      end
+    end
+  end
 end

--- a/spec/source/_config.yml
+++ b/spec/source/_config.yml
@@ -1,0 +1,7 @@
+collections:
+  my_collection:
+    output: true
+
+# Basic config needed for Jekyll to run
+url: "http://localhost:4000"
+baseurl: "" 

--- a/spec/source/_my_collection/item1.md
+++ b/spec/source/_my_collection/item1.md
@@ -1,0 +1,9 @@
+---
+title: Collection Item One
+layout: default
+date: 2024-01-10
+---
+
+## Item 1 Content
+
+Details about the first item. 

--- a/spec/source/about.md
+++ b/spec/source/about.md
@@ -1,0 +1,8 @@
+---
+title: About Us
+layout: default
+---
+
+# About This Site
+
+This is the about page. 


### PR DESCRIPTION
## What?
This PR introduces the ability to generate OG images for Jekyll pages and custom collections, not just posts.
    
## Why?
Addresses the limitation of the plugin only working for posts.
   
## How?
Adds a `content_types` array to the `og_image` configuration in `_config.yml`. The generator now iterates over these types. 

Includes tests and fixes for Jekyll 3.x compatibility.  **Maintains backward compatibility**; users who don't add content_types will see no change.
    
## Details
    - Adds `content_types` option to _config.yml to specify processing posts, pages, and custom collections. Defaults to ['posts'] for backward compatibility.
    - Refactors generator to iterate specified types and output to type-specific subdirectories.
    - Adds RSpec tests for new functionality.
    - Fixes filename generation for Jekyll 3.x compatibility.
    - Fixes domain text positioning for visual backward compatibility.
    - Adds csv dev dependency for Ruby 3.4 test compatibility.