### PR TITLE
Flatten inset images

### DIFF
--- a/lib/jekyll_og_image/element/image.rb
+++ b/lib/jekyll_og_image/element/image.rb
@@ -15,6 +15,10 @@ class JekyllOgImage::Element::Image < JekyllOgImage::Element::Base
     image = Vips::Image.new_from_buffer(@source, "")
     image = round_corners(image) if @radius
 
+    if image.bands != canvas.bands
+      image = image.flatten
+    end
+
     if @width && @height
       ratio = calculate_ratio(image, @width, @height, :min)
       image = image.resize(ratio)

--- a/lib/jekyll_og_image/element/image.rb
+++ b/lib/jekyll_og_image/element/image.rb
@@ -13,11 +13,12 @@ class JekyllOgImage::Element::Image < JekyllOgImage::Element::Base
 
   def apply_to(canvas, &block)
     image = Vips::Image.new_from_buffer(@source, "")
-    image = round_corners(image) if @radius
 
     if image.bands != canvas.bands
       image = image.flatten
     end
+
+    image = round_corners(image) if @radius
 
     if @width && @height
       ratio = calculate_ratio(image, @width, @height, :min)


### PR DESCRIPTION
I found that vips would fall over if the inset image (e.g. profile picture) has an alpha channel. Flattening the image to remove the alpha channel appears to work - vips doesn't complain and the image shows up correctly in the output.

This has to happen before rounding the corners, otherwise the image ends up with black corners.

I don't know ruby so this can probably be done more robustly. Appreciate your feedback.