### PR TITLE
Add generated image to site static files during generation

### DIFF
--- a/lib/jekyll_og_image/generator.rb
+++ b/lib/jekyll_og_image/generator.rb
@@ -49,6 +49,8 @@ class JekyllOgImage::Generator < Jekyll::Generator
         Jekyll.logger.info "Jekyll Og Image:", "Skipping image generation for #{relative_image_path} as it already exists." if config.verbose?
       end
 
+      site.static_files << Jekyll::StaticFile.new(site, site.source, base_output_dir, image_filename)
+
       item.data["image"] ||= {
         "path" => relative_image_path,
         "width" => JekyllOgImage.config.canvas.width,


### PR DESCRIPTION
Thanks for making this plugin!

I ran into https://github.com/igor-alexandrov/jekyll-og-image/issues/14 while setting this up on my blog and think I figured out the fix is to make sure the generated images are marked as static files so they're copied over to the output directory during the first build.

I verified this locally on my own blog by patching the code in my local installation of the Gem, removing the generated images from my assets directory and nuking the `_site` folder, and confirming that the files were generated + copied on a clean build.

I'm not super familiar with Jekyll plugins so if there is a better way to write verification tests for this let me know!